### PR TITLE
Add schema validation workflow

### DIFF
--- a/.github/workflows/schemavalidation.yaml
+++ b/.github/workflows/schemavalidation.yaml
@@ -1,0 +1,22 @@
+name: Tests of YAML configuration and schema
+
+on: [push, pull_request]
+
+jobs:
+    validate:
+        name: Validate configuration against a schema and validate the schema itself
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.6
+            - name: Install dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install jsonschema PyYAML
+            - name: Validate default config
+              run: python ./tests/validate_schema.py ./config/schema.yaml --config ./config/default.yaml
+            - name: Validate schema itself
+              run: python ./tests/validate_schema.py ./config/schema.yaml

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -81,6 +81,7 @@ properties:
                         description: Maximum Latitude, in degrees north
                 description: Total extent of system under study. Defaults to all of Europe
             exclusion_zones:
+                type: object
                 patternProperties:
                     ^.*$:
                         properties:
@@ -106,7 +107,7 @@ properties:
                                 description: Maximum Latitude, in degrees north
                 description: Any number of bounding boxes defining exclusion zones, where spatial features within the total bounds are to be ignored.
     layers:
-        scope: object
+        type: object
         patternProperties:
             ^.*$:
                 type: object

--- a/tests/validate_schema.py
+++ b/tests/validate_schema.py
@@ -1,0 +1,27 @@
+import argparse
+import jsonschema
+import yaml
+
+parser = argparse.ArgumentParser()
+parser.add_argument("schema", help="JSON schema in YAML format")
+parser.add_argument(
+    "--config",
+    help=(
+        "configuration file to validate. "
+        "If not given, schema itself will be validated against JSON schema Draft 7"
+    )
+)
+args = parser.parse_args()
+
+with open(args.schema, "r") as f:
+    schema = yaml.safe_load(f)
+
+if args.config:
+    with open(args.config, "r") as f:
+        config = yaml.safe_load(f)
+    jsonschema.validate(config, schema)
+else:
+    # We set the metaschema 'additionalProperties' to False to create a 'strict' schema checker,
+    # which will fail on typos
+    jsonschema.Draft7Validator.META_SCHEMA['additionalProperties'] = False
+    jsonschema.Draft7Validator.check_schema(schema)


### PR DESCRIPTION
As recently added in https://github.com/calliope-project/euro-calliope, this adds a github workflow job to validate the default YAML config and to check the validity of the schema itself.