### PR TITLE
Simplified approach to updating slope source

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Whenever possible, data is downloaded automatically. As this is not always possi
 * [European Settlement Map 2012, Release 2017, 100m](https://land.copernicus.eu/pan-european/GHSL/european-settlement-map), to be placed at `./data/esm-100m-2017/`
 * [World Exclusive Economic Zones v10](http://www.marineregions.org/downloads.php), to be placed in `./data/World_EEZ_v10_20180221`
 * capacity factors from renewable.ninja, to be placed in `./data/capacityfactors/{technology}.nc` for technology in ["wind-onshore", "wind-offshore", "rooftop-pv", "open-field-pv"] (where "open-field-pv" and "rooftop-pv" can be the same dataset and hence can be linked instead of copied)(to run simulations, see `Manual steps` below)
+* [EU-DEM v1.0 slope data, Full European Coverage](https://land.copernicus.eu/imagery-in-situ/eu-dem/eu-dem-v1-0-and-derived-products/slope), to be placed at `./data/eudem_slop_3035_europe.tif`
 
 ## Run the analysis
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,8 +7,6 @@ data-sources:
     degurba: http://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/DGURBA_2014_SH.zip
     land_cover: http://due.esrin.esa.int/files/Globcover2009_V2.3_Global_.zip
     protected_areas: https://www.protectedplanet.net/downloads/WDPA_Feb2019?type=shapefile
-    cgiar_tile: http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/
-    gmted_tile: https://edcintl.cr.usgs.gov/downloads/sciweb1/shared/topo/downloads/GMTED/Global_tiles_GMTED/075darcsec/mea/
     gadm: https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/gadm36_{country_code}_gpkg.zip
     bathymetric: https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO1/data/bedrock/grid_registered/georeferenced_tiff/ETOPO1_Bed_g_geotiff.zip
     pop: http://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_POP_GPW4_GLOBE_R2015A/GHS_POP_GPW42015_GLOBE_R2015A_54009_250/V1-0/GHS_POP_GPW42015_GLOBE_R2015A_54009_250_v1_0.zip
@@ -18,6 +16,7 @@ data-sources:
     sonnendach_total_size: https://zenodo.org/record/4091033/files/total-rooftop-area-km2.txt?download=1
     sonnendach_total_yield: https://zenodo.org/record/4091033/files/total-yield-twh.txt?download=1
     raw-capacity-factors: data/capacityfactors/{technology}.nc
+    slope: data/eudem_slop_3035_europe.tif
 root-directory: . # point to the root directory if working directory is not root directory
 crs: "EPSG:4326"
 scope:

--- a/rules/data-preprocessing.smk
+++ b/rules/data-preprocessing.smk
@@ -1,22 +1,12 @@
 """This is a Snakemake file defining rules to retrieve raw data from online sources."""
 import pycountry
 
-RESOLUTION_STUDY = (1 / 3600) * 10 # 10 arcseconds
-RESOLUTION_SLOPE = (1 / 3600) * 3 # 3 arcseconds
-
-SRTM_X_MIN = 34 # x coordinate of CGIAR tile raster
-SRTM_X_MAX = 44
-SRTM_Y_MIN = 1 # y coordinate of CGIAR tile raster
-SRTM_Y_MAX = 8
-GMTED_Y = ["50N", "70N"]
-GMTED_X = ["030W", "000E", "030E"]
-
 root_dir = config["root-directory"] + "/" if config["root-directory"] not in ["", "."] else ""
 script_dir = f"{root_dir}scripts/"
 
 localrules: raw_gadm_administrative_borders_zipped, raw_protected_areas_zipped,
     raw_lau_units_zipped, raw_land_cover_zipped,
-    raw_land_cover, raw_protected_areas, raw_srtm_elevation_tile_zipped, raw_gmted_elevation_tile,
+    raw_land_cover, raw_protected_areas,
     raw_bathymetry_zipped, raw_bathymetry, raw_gadm_administrative_borders
 
 
@@ -138,70 +128,6 @@ rule raw_protected_areas:
     shell: "unzip -o {input} -d build/raw-wdpa-feb2019"
 
 
-rule raw_srtm_elevation_tile_zipped:
-    message: "Download SRTM elevation data tile (x={wildcards.x}, y={wildcards.y}) from CGIAR."
-    output: protected("data/automatic/raw-srtm/srtm_{x}_{y}.zip")
-    params: url = config["data-sources"]["cgiar_tile"]
-    shell: "curl -sLo {output} '{params.url}/srtm_{wildcards.x}_{wildcards.y}.zip'"
-
-
-rule raw_srtm_elevation_tile:
-    message: "Unzip SRTM elevation data tile (x={wildcards.x}, y={wildcards.y})."
-    input:
-        "data/automatic/raw-srtm/srtm_{x}_{y}.zip"
-    output:
-        temp("build/srtm_{x}_{y}.tif")
-    run: # using Python here, because "unzip" issues a warning sometimes causing snakemake to break
-        import zipfile
-        from pathlib import Path
-
-        file_to_extract = Path(input[0]).with_suffix(".tif").name
-        with zipfile.ZipFile(input[0], "r") as zipref:
-            zipref.extract(file_to_extract, path="build")
-
-
-rule raw_srtm_elevation_data:
-    message: "Merge all SRTM elevation data tiles."
-    input:
-        ["build/srtm_{x:02d}_{y:02d}.tif".format(x=x, y=y)
-         for x in range(SRTM_X_MIN, SRTM_X_MAX + 1)
-         for y in range(SRTM_Y_MIN, SRTM_Y_MAX + 1)
-         if not (x is 34 and y in [3, 4, 5, 6])] # these tiles do not exist
-    output:
-        temp("build/raw-srtm-elevation-data.tif")
-    conda: "../envs/default.yaml"
-    shell:
-        "rio merge {input} {output} --overwrite"
-
-
-rule raw_gmted_elevation_tile:
-    message: "Download GMTED elevation data tile."
-    output:
-        protected("data/automatic/raw-gmted/raw-gmted-{y}-{x}.tif")
-    run:
-        url = "{base_url}/{x_inverse}/{y}{x}_20101117_gmted_mea075.tif".format(**{
-            "base_url": config["data-sources"]["gmted_tile"],
-            "x": wildcards.x,
-            "y": wildcards.y,
-            "x_inverse": wildcards.x[-1] + wildcards.x[:-1]
-        })
-        shell("curl -sLo {output} '{url}'".format(**{"url": url, "output": output}))
-
-
-rule raw_gmted_elevation_data:
-    message: "Merge all GMTED elevation data tiles."
-    input:
-        ["data/automatic/raw-gmted/raw-gmted-{y}-{x}.tif".format(x=x, y=y)
-         for x in GMTED_X
-         for y in GMTED_Y
-         ]
-    output:
-        temp("build/raw-gmted-elevation-data.tif")
-    conda: "../envs/default.yaml"
-    shell:
-        "rio merge {input} {output} --overwrite"
-
-
 rule raw_bathymetry_zipped:
     message: "Download bathymetric data as zip."
     output: protected("data/automatic/raw-bathymetric.zip")
@@ -216,31 +142,6 @@ rule raw_bathymetry:
     shell: "unzip {input} -d ./build/"
 
 
-rule elevation_in_europe:
-    message: "Merge SRTM and GMTED elevation data and warp/clip to Europe using {threads} threads."
-    input:
-        gmted = rules.raw_gmted_elevation_data.output,
-        srtm = rules.raw_srtm_elevation_data.output
-    output:
-        temp("build/elevation-europe.tif")
-    params:
-        srtm_bounds = "{x_min},{y_min},{x_max},60".format(**config["scope"]["bounds"]),
-        gmted_bounds = "{x_min},59.5,{x_max},{y_max}".format(**config["scope"]["bounds"])
-    threads: config["snakemake"]["max-threads"]
-    conda: "../envs/default.yaml"
-    shell:
-        """
-        rio clip --bounds {params.srtm_bounds} {input.srtm} -o build/tmp-srtm.tif
-        rio clip --bounds {params.gmted_bounds} {input.gmted} -o build/tmp-gmted.tif
-        rio warp build/tmp-gmted.tif -o build/tmp-gmted2.tif -r {RESOLUTION_SLOPE} \
-        --resampling nearest --threads {threads}
-        rio merge build/tmp-srtm.tif build/tmp-gmted2.tif {output}
-        rm build/tmp-gmted.tif
-        rm build/tmp-gmted2.tif
-        rm build/tmp-srtm.tif
-        """
-
-
 rule land_cover_in_europe:
     message: "Clip land cover data to Europe."
     input: rules.raw_land_cover.output
@@ -250,10 +151,10 @@ rule land_cover_in_europe:
     shell: "rio clip {input} {output} --bounds {params.bounds}"
 
 
-rule slope_in_europe:
-    message: "Calculate slope and warp to resolution of study using {threads} threads."
+rule integer_slope_in_europe:
+    message: "Warp slope to resolution of study using {threads} threads."
     input:
-        elevation = rules.elevation_in_europe.output,
+        slope = config["data-sources"]["slope"],
         land_cover = rules.land_cover_in_europe.output
     output:
         "build/slope-europe.tif"
@@ -261,10 +162,8 @@ rule slope_in_europe:
     conda: "../envs/default.yaml"
     shell:
         """
-        gdaldem slope -s 111120 -compute_edges {input.elevation} build/slope-temp.tif
-        rio warp build/slope-temp.tif -o {output} --like {input.land_cover} \
-        --resampling max --threads {threads}
-        rm build/slope-temp.tif
+        rio warp {input.slope} -o {output} --like {input.land_cover} \
+        --resampling min --threads {threads}
         """
 
 

--- a/rules/potential.smk
+++ b/rules/potential.smk
@@ -15,7 +15,7 @@ rule category_of_technical_eligibility:
     input:
         src = script_dir + "technical_eligibility.py",
         land_cover = rules.land_cover_in_europe.output[0],
-        slope = rules.slope_in_europe.output[0],
+        integer_slope = rules.integer_slope_in_europe.output[0],
         bathymetry = rules.bathymetry_in_europe.output[0],
         building_share = rules.settlements.output.buildings,
         urban_green_share = rules.settlements.output.urban_greens

--- a/scripts/technical_eligibility.py
+++ b/scripts/technical_eligibility.py
@@ -9,7 +9,7 @@ import rasterio
 from renewablepotentialslib.eligibility import eligibility_land_mask, DATATYPE
 
 
-def determine_eligibility(path_to_land_cover, path_to_slope, path_to_bathymetry,
+def determine_eligibility(path_to_land_cover, path_to_integer_slope, path_to_bathymetry,
                           path_to_building_share, path_to_urban_green_share, path_to_result,
                           max_slope, max_building_share, max_urban_green_share, max_depth_offshore):
     """Determines eligibility of land for renewables."""
@@ -17,8 +17,9 @@ def determine_eligibility(path_to_land_cover, path_to_slope, path_to_bathymetry,
         transform = src.transform
         land_cover = src.read(1)
         crs = src.crs
-    with rasterio.open(path_to_slope) as src:
-        slope = src.read(1)
+    with rasterio.open(path_to_integer_slope) as src:
+        # see https://land.copernicus.eu/user-corner/technical-library/slope-conversion-table
+        slope = np.degrees(np.arccos(src.read(1) / 250))
     with rasterio.open(path_to_bathymetry) as src:
         bathymetry = src.read(1)
     with rasterio.open(path_to_building_share) as src:
@@ -49,7 +50,7 @@ if __name__ == "__main__":
         path_to_bathymetry=snakemake.input.bathymetry,
         path_to_building_share=snakemake.input.building_share,
         path_to_urban_green_share=snakemake.input.urban_green_share,
-        max_slope=snakemake.params.max_slope,
+        max_integer_slope=snakemake.params.max_integer_slope,
         max_building_share=snakemake.params.max_building_share,
         max_urban_green_share=snakemake.params.max_urban_green_share,
         max_depth_offshore=snakemake.params.max_depth_offshore,

--- a/scripts/technical_eligibility.py
+++ b/scripts/technical_eligibility.py
@@ -46,11 +46,11 @@ def determine_eligibility(path_to_land_cover, path_to_integer_slope, path_to_bat
 if __name__ == "__main__":
     determine_eligibility(
         path_to_land_cover=snakemake.input.land_cover,
-        path_to_slope=snakemake.input.slope,
+        path_to_integer_slope=snakemake.input.integer_slope,
         path_to_bathymetry=snakemake.input.bathymetry,
         path_to_building_share=snakemake.input.building_share,
         path_to_urban_green_share=snakemake.input.urban_green_share,
-        max_integer_slope=snakemake.params.max_integer_slope,
+        max_slope=snakemake.params.max_slope,
         max_building_share=snakemake.params.max_building_share,
         max_urban_green_share=snakemake.params.max_urban_green_share,
         max_depth_offshore=snakemake.params.max_depth_offshore,


### PR DESCRIPTION
Almost identical result to #15 but with the `0-250` integer-based slope data being warped to land-cover resolution, and only converted to degrees when needed. 

There are ~2-3% more valid tiles resulting from this approach than the current method.

This implementation is less powerful than #15, as one cannot infer the percentage of the aggregated tile that is suitable for deployment based on slope, but this simplification is in-keeping with maintaining the scope of the workflow whilst changing the data source.